### PR TITLE
authoring/tools-for-developers: Fix link inside a note 

### DIFF
--- a/authoring/tools-for-developers.md
+++ b/authoring/tools-for-developers.md
@@ -64,8 +64,7 @@ repos:
 ```
 
 ```{note}
-See [the flake8 hooks explanation](see: https://flake8.pycqa.org/en/latest/user/using-hooks.html) 
-for more details
+See [the flake8 hooks explanation](https://flake8.pycqa.org/en/latest/user/using-hooks.html) for more details.
 ```
 
 This file specifies a hook that will be triggered automatically before each `git commit`,


### PR DESCRIPTION
Add tools for development to menu and fix link inside the note.

I just saw that the other filenames use underscore instead of dash. 
I created the file using dash, should I change to underscore? In general dash is more used or recommend (for example https://support.google.com/webmasters/answer/76329?hl=en), but I can change to underscore with no problem.

note: menu was already added! thanks @lwasser 