### PR TITLE
minor document updates and adding repository buttons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
     steps:
       - checkout
       - run: pip install -r requirements.txt
-      - run: pip install -U --pre jupyter-book
       - run:
           name: Build site markdown
           command: jupyter-book build .

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,8 +23,6 @@ jobs:
     - name: Install Jupyter Book
       run: |
         pip install -r requirements.txt
-        pip install -U --pre jupyter-book
-
 
     # Build the book
     - name: Build the book

--- a/_config.yml
+++ b/_config.yml
@@ -6,9 +6,12 @@ exclude_patterns: ["README.md"]
 
 repository:
   url: https://github.com/pyOpenSci/dev_guide
+  branch: master
 
 html:
   favicon: images/logo/logo.png
   google_analytics_id: UA-165151943-1
   use_edit_page_button: true
+  use_issues_button: true
+  use_repository_button: true
   home_page_in_navbar: false

--- a/_toc.yml
+++ b/_toc.yml
@@ -8,14 +8,14 @@ sections:
   - file: open-source-software-peer-review/policies-and-guidelines
 - file: open-source-software-submissions/intro
   sections:
-  - file: open-source-software-submissions/editors-guide
-  - file: open-source-software-submissions/editor-in-chief-guide
   - file: open-source-software-submissions/author-guide
   - file: open-source-software-submissions/reviewer-guide
+  - file: open-source-software-submissions/editors-guide
+  - file: open-source-software-submissions/editor-in-chief-guide
 - file: authoring/index
   sections:
-  - file: authoring/collaboration
   - file: authoring/overview
+  - file: authoring/collaboration
   - file: authoring/tools-for-developers
   - file: authoring/testing
   - file: authoring/release

--- a/authoring/index.md
+++ b/authoring/index.md
@@ -5,14 +5,22 @@ pyOpenSci review process. This includes best-practices and guidelines for struct
 and releasing your code, as well as considerations to take before you begin your
 submission.
 
+```{tableofcontents}
+```
+
 ## Code Style
 
 pyOpenSci encourages authors to consult [PEP 8](https://www.python.org/dev/peps/pep-0008/) for information on how to style your code.
 
 ## Packaging Guide
 
-The [first section of this guidebook](overview) has info for creating and packaging your Python project for review and release. The guide also includes info on the basic requirements for pyOpenSci: testing, continuous integration, documentation, etc.
+The [first section of this guidebook](overview) has info for creating and packaging your
+Python project for review and release. The guide also includes info on the basic
+requirements for pyOpenSci: testing, continuous integration, documentation, etc.
 
-We also have a [section](release) about releasing your package on PyPI, but we encourage you to wait until after the pyOpenSci review process has finished before uploading to PyPI. This makes it easier to incorporate changes/suggestions from the reviews.
+We also have a [section](release) about releasing your package on PyPI, but we encourage
+you to wait until after the pyOpenSci review process has finished before uploading to
+PyPI. This makes it easier to incorporate changes/suggestions from the reviews.
 
-PyPI also has a [short tutorial](https://packaging.python.org/tutorials/packaging-projects/) on how to package a Python project for easy installation.
+PyPI also has a [short tutorial](https://packaging.python.org/tutorials/packaging-projects/)
+on how to package a Python project for easy installation.

--- a/open-source-software-peer-review/intro.md
+++ b/open-source-software-peer-review/intro.md
@@ -2,6 +2,9 @@
 
 These pages contain information about the peer review process.
 
+```{tableofcontents}
+```
+
 ## The Peer Review Timeline
 
 - *Pre-submission:* If you are unsure if your package fits within the scope of the pyOpenSci suite, create a pre-submission inquiry issue on the [pyopensci/software-review repository](https://github.com/pyOpenSci/software-review/issues/new/choose). An editor will respond within a few days to let you know if we can review your package at this time. For more info, see the ["Aims and Scope"](aims-and-scope) section of this guide.

--- a/open-source-software-peer-review/policies-and-guidelines.md
+++ b/open-source-software-peer-review/policies-and-guidelines.md
@@ -1,18 +1,42 @@
-# pyOpenSci Open Source Software Peer Review Guidelines & Policies
+# Peer Review Guidelines & Policies
 
 ## Review Process Guidelines
-- Packages are reviewed for quality, fit, documentation, clarity and the review process is quite similar to a manuscript review (see our [packaging guide](../authoring/overview) and [reviewing guide](../open-source-software-submissions/reviewer-guide) for more details). Unlike a manuscript review, this process will be an ongoing conversation.
-- Once all major issues and questions, and those addressable with reasonable effort, are resolved, the editor assigned to a package will make a decision (accept, hold, or reject). Rejections are usually done early (before the review process begins, see the aims and scope section), but in rare cases a package may also be not onboarded after review & revision. It is ultimately editor’s decision on whether or not to reject the package based on how the reviews are addressed.
-- Communication between authors, reviewers and editors will first and foremost take place on GitHub, although you can choose to contact the editor by email. When submitting a package, please make sure your GitHub notification settings make it unlikely you will miss a comment.
-- The author can choose to have their submission put on hold (editor applies the holding label). The holding status will be revisited every 3 months, and after one year the issue will be closed.
-- If the author hasn’t requested a holding label, but is simply not responding, we should close the issue within one month after the last contact intent. This intent will include a comment tagging the author, but also an email using the email address listed in the DESCRIPTION of the package which is one of the rare cases where the editor will try to contact the author by email.
-- If a submission is closed and the author wishes to re-submit, they’ll have to start a new submission. If the package is still in scope, the author will have to respond to the initial reviews before the editor starts looking for new reviewers.
+
+- Packages are reviewed for quality, fit, documentation, clarity and the review process
+  is quite similar to a manuscript review (see our [packaging guide](../authoring/overview)
+  and [reviewing guide](../open-source-software-submissions/reviewer-guide) for more details). Unlike a
+  manuscript review, this process will be an ongoing conversation.
+- Once all major issues and questions, and those addressable with reasonable effort, are
+  resolved, the editor assigned to a package will make a decision (accept, hold, or
+  reject). Rejections are usually done early (before the review process begins, see the
+  aims and scope section), but in rare cases a package may also be not onboarded after
+  review & revision. It is ultimately editor’s decision on whether or not to reject the
+  package based on how the reviews are addressed.
+- Communication between authors, reviewers and editors will first and foremost take
+  place on GitHub, although you can choose to contact the editor by email. When
+  submitting a package, please make sure your GitHub notification settings make it
+  unlikely you will miss a comment.
+- The author can choose to have their submission put on hold (editor applies the holding
+  label). The holding status will be revisited every 3 months, and after one year the
+  issue will be closed.
+- If the author hasn’t requested a holding label, but is simply not responding, we
+  should close the issue within one month after the last contact intent. This intent
+  will include a comment tagging the author, but also an email using the email address
+  listed in the DESCRIPTION of the package which is one of the rare cases where the
+  editor will try to contact the author by email.
+- If a submission is closed and the author wishes to re-submit, they’ll have to start a
+  new submission. If the package is still in scope, the author will have to respond to
+  the initial reviews before the editor starts looking for new reviewers.
 
 ### Conflict of interest
-Following criteria are meant to be a guide for what constitutes a conflict of interest for an editor or reviewer. The potential editor or reviewer has a conflict of interest if:
+Following criteria are meant to be a guide for what constitutes a conflict of interest
+for an editor or reviewer. The potential editor or reviewer has a conflict of interest
+if:
 
 - The authors with a major role are from the potential reviewer/editor’s institution or institutional component (e.g., department)
-- Within in the past three years, the potential reviewer/editor has been a collaborator or has had any other professional relationship with any person on the package who has a major role
+- Within in the past three years, the potential reviewer/editor has been a collaborator
+  or has had any other professional relationship with any person on the package who has
+  a major role
 - The potential reviewer/editor serves as a member of the advisory board for the project under review
 - The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted
 - The potential reviewer/editor has significantly contributed to a competitor project.
@@ -22,17 +46,33 @@ In the case where none of the associate editors can serve as editor, an external
 
 ## After Acceptance: Package Ownership and Maintenance
 
-Authors of contributed packages essentially maintain the same ownership they had prior to their package joining the pyOpenSci suite. Package authors will continue to maintain and develop their software after acceptance into pyOpenSci. Unless explicitly added as collaborators, the pyOpenSci team will not interfere much with day to day operations. However, the team may intervene with critical bug fixes, or address urgent issues if package authors do not respond in a timely manner (see the section about maintainer responsiveness).
+Authors of contributed packages essentially maintain the same ownership they had prior
+to their package joining the pyOpenSci suite. Package authors will continue to maintain
+and develop their software after acceptance into pyOpenSci. Unless explicitly added as
+collaborators, the pyOpenSci team will not interfere much with day to day operations.
+However, the team may intervene with critical bug fixes, or address urgent issues if
+package authors do not respond in a timely manner (see the section about maintainer
+responsiveness).
 
 ### Quality Commitment
-pyOpenSci strives to develop and promote high quality research software. To ensure that your software meets our criteria, we review all of our submissions as part of the Software Peer Review process, and even after acceptance will continue to step in with improvements and bug fixes.
+pyOpenSci strives to develop and promote high quality research software. To ensure that
+your software meets our criteria, we review all of our submissions as part of the
+Software Peer Review process, and even after acceptance will continue to step in with
+improvements and bug fixes.
 
-Despite our best efforts to support contributed software, errors are the responsibility of individual maintainers. Buggy, unmaintained software may be removed from our suite at any time.
+Despite our best efforts to support contributed software, errors are the responsibility
+of individual maintainers. Buggy, unmaintained software may be removed from our suite at
+any time.
 
 ### Maintener Responsiveness
-If package maintainers do not respond in a timely manner to requests for package fixes, we will remind the maintainer a number of times, but after 3 months (or shorter time frame, depending on how critical the fix is) we will make the changes ourselves.
+If package maintainers do not respond in a timely manner to requests for package fixes,
+we will remind the maintainer a number of times, but after 3 months (or shorter time
+frame, depending on how critical the fix is) we will make the changes ourselves.
 
-Should authors abandon the maintenance of an actively used package in our suite, we will consider petitioning PyPI to transfer package maintainer status to pyOpenSci.
+Should authors abandon the maintenance of an actively used package in our suite, we will
+consider petitioning PyPI to transfer package maintainer status to pyOpenSci.
 
 ### Requesting Package Removal
-In the unlikely scenario that a contributor of a package requests removal of their package from the suite, we retain the right to maintain a version of the package in our suite for archival purposes.
+In the unlikely scenario that a contributor of a package requests removal of their
+package from the suite, we retain the right to maintain a version of the package in our
+suite for archival purposes.

--- a/open-source-software-submissions/editor-in-chief-guide.md
+++ b/open-source-software-submissions/editor-in-chief-guide.md
@@ -1,6 +1,6 @@
-# pyOpenSci Editor in Chief Guide
+# Editor in Chief Guide
 
-## Editor in Chief Role & Responsibilities 
+## Editor in Chief Role & Responsibilities
 
 The Editor in Chief serves for 3 months or a time agreed to by all members of the editorial board. The Editor in Chief fulfills the following roles:
 

--- a/open-source-software-submissions/intro.md
+++ b/open-source-software-submissions/intro.md
@@ -2,3 +2,6 @@
 
 These are a collection of guides for the peer review and submission process.
 They are broken down by the various roles that carry out a submission.
+
+```{tableofcontents}
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book
+jupyter-book>=0.7.0b


### PR DESCRIPTION
This makes some minor formatting and structure updates to make the docs a bit easier to read in pure-text (e.g. splitting really long lines into multiple shorter lines). It re-orders a couple of pages to (I think) more naturally flow (e.g. "overview" should go first). It also renames the titles of a few pages that felt awkwardly long.