### PR TITLE
Fix urls in various places throughout the contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# <img src="content/images/logo/logo.png" width=40 /> pyOpenSci Guidebook
-[![CircleCI](https://circleci.com/gh/pyOpenSci/dev_guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide)
+# <img src="images/logo/logo.png" width=40 /> pyOpenSci Guidebook
+[![CircleCI](https://circleci.com/gh/pyOpenSci/contributing-guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide)
 
 https://pyopensci.org/contributing-guide/
 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ To build the guide locally, take the following steps:
 ## Contributing to this guide
 
 We welcome and issues and pull-requests to improve the content of this guide.
-If you'd like to see an improvement, please [open an issue](https://github.com/pyOpenSci/dev_guide/issues/new/choose).
+If you'd like to see an improvement, please [open an issue](https://github.com/pyOpenSci/contributing-guide/issues/new/choose).

--- a/appendices/templates.md
+++ b/appendices/templates.md
@@ -7,7 +7,7 @@ These are templates to be used by editors and reviewers. When a package is submi
 ```
 ## Editor checks:
 
-- [ ] **Fit**: The package meets criteria for [fit](https://pyopensci.github.io/dev_guide/peer_review/aims-and-scope.html#package-categories) and [overlap](https://pyopensci.github.io/dev_guide/peer_review/aims-and-scope.html#package-categories).
+- [ ] **Fit**: The package meets criteria for [fit](https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html#package-categories) and [overlap](https://www.pyopensci.org/contributing-guide/open-source-software-peer-review/aims-and-scope.html#package-overlap).
 - [ ] **Automated tests:** Package has a testing suite and is tested via Travis-CI or another CI service.
 - [ ] **License:** The package has an OSI accepted license
 - [ ] **Repository:** The repository link resolves correctly
@@ -78,7 +78,7 @@ Package structure should follow general community best-practices. In general ple
 - [ ] **Performance:** Any performance claims of the software been confirmed.
 - [ ] **Automated tests:** Tests cover essential functions of the package and a reasonable range of inputs and conditions. All tests pass on the local machine.
 - [ ] **Continuous Integration:** Has continuous integration, such as Travis CI, AppVeyor, CircleCI, and/or others.
-- [ ] **Packaging guidelines**: The package conforms to the pyOpenSci [packaging guidelines](https://www.pyopensci.org/dev_guide/authoring/overview.html).
+- [ ] **Packaging guidelines**: The package conforms to the pyOpenSci [packaging guidelines](https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide).
 
 #### For packages co-submitting to JOSS
 
@@ -131,9 +131,9 @@ Sincerely,
 
 [EDITOR]
 
-[reviewers guide]: https://pyopensci.github.io/dev_guide/peer_review/reviewer_guide.html
-[packaging guide]: https://pyopensci.github.io/dev_guide/authoring/overview.html
-[template]: https://pyopensci.github.io/dev_guide/appendices/templates.html#review-template
+[reviewers guide]: https://www.pyopensci.org/contributing-guide/open-source-software-submissions/reviewer-guide.html
+[packaging guide]: https://www.pyopensci.org/contributing-guide/authoring/index.html#packaging-guide
+[template]: https://www.pyopensci.org/contributing-guide/appendices/templates.html#review-template
 
 
 ## Editor Approval Comment Template

--- a/authoring/collaboration.md
+++ b/authoring/collaboration.md
@@ -1,6 +1,6 @@
 # Collaboration Guide
 
-Note: pyOpenSci is still building out this section of our guidebook. Many of the examples come from rOpenSci. If you have suggestions for changes, check out the [GitHub repo](https://github.com/pyOpenSci/dev_guide).
+Note: pyOpenSci is still building out this section of our guidebook. Many of the examples come from rOpenSci. If you have suggestions for changes, check out the [GitHub repo](https://github.com/pyOpenSci/contributing-guide).
 
 ## Make your repo contribution and collaboration friendly
 
@@ -10,7 +10,7 @@ We require that you use a code of conduct such as the [Contributor Covenant](htt
 
 ### Contributing guide
 
-We have a [template for contributing guidelines](https://github.com/pyOpenSci/cookiecutter-pyopensci/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst) in our cookiecutter repository. Even if you're not using cookiecutter to build your project (see our [packaging guide](../packaging/#project-template) for info), you can download our CONTRIBUTING.rst as a starting point.
+We have a [template for contributing guidelines](https://github.com/pyOpenSci/cookiecutter-pyopensci/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/CONTRIBUTING.rst) in our cookiecutter repository. Even if you're not using cookiecutter to build your project (see our [packaging guide](../authoring/overview#project-template) for info), you can download our CONTRIBUTING.rst as a starting point.
 
 You can tweak it a bit depending on your workflow and package. For example, make sure contributors have instructions in your CONTRIBUTING file for running local tests if not trivial. CONTRIBUTING can also contain some details about how you acknowledge contributions (see [this section](#attributions)) and the roadmap of your package (cf [this example for R](https://github.com/ecohealthalliance/fasterize/blob/master/CONTRIBUTING.md)).
 

--- a/intro.md
+++ b/intro.md
@@ -14,10 +14,10 @@ This guidebook contains information for pyOpenSci package authors, reviewers, an
 Contains our guidelines for creating and testing scientific python packages. Before submitting a package for review, check to be sure that your software meets the basic [requirements](authoring/overview#overview). The section also contains recommendations and best practices that might be helpful as you are writing and preparing your package.
 
 ### 2. Peer Review Process
-Outlines the pyOpenSci peer review process. This includes guidelines for submitting and reviewing packages, as well as our [Code of Conduct](open-source-software-peer-review/code-of-conduct). The [Aims and Scope](open-source-software-peer-review/aims-and-scope) section lays out what types of packages we are able to review. If you are unsure whether your package fits, we encourage you to submit a [presubmission inquiry](submissions/author_guide#presubmission)
+Outlines the pyOpenSci peer review process. This includes guidelines for submitting and reviewing packages, as well as our [Code of Conduct](open-source-software-peer-review/code-of-conduct). The [Aims and Scope](open-source-software-peer-review/aims-and-scope) section lays out what types of packages we are able to review. If you are unsure whether your package fits, we encourage you to submit a [presubmission inquiry](open-source-software-submissions/author-guide#presubmission)
 
 ### 3. After Review - Maintenance
 Provides tips and advice for maintaining and promoting your pyOpenSci package after the review process has finished.
 
 ## Improving this Guide
-The pyOpenSci guidebook is a living document hosted on GitHub. If you have suggestions for improvements, create an issue or submit a pull request on [GitHub](https://github.com/pyOpenSci/dev_guide).
+The pyOpenSci guidebook is a living document hosted on GitHub. If you have suggestions for improvements, create an issue or submit a pull request on [GitHub](https://github.com/pyOpenSci/contributing-guide).

--- a/open-source-software-submissions/editors-guide.md
+++ b/open-source-software-submissions/editors-guide.md
@@ -5,7 +5,7 @@
 - Add a comment to the issue with your response to the Editor Checks.
   - Use the [editor template](../appendices/templates#editors-template).
   - Fill out the Editor Checks sections for `Fit`, `Automated Tests`, `License`, `Repository`
-    - Check against policies for [fit](aims_scope#package-categories) and [overlap](aims_scope#package-overlap). If reject, see [this section](#responding-to-out-of-scope-submissions) about how to respond.
+    - Check against policies for [fit](aims-and-scope#package-categories) and [overlap](aims-and-scope#package-overlap). If reject, see [this section](editor-in-chief-guide#responding-to-out-of-scope-submissions) about how to respond.
     - `Archive` and `Version` for JOSS may be filled out at the end of the review.
 - Check the comment submission by the author to ensure that mandatory parts of submission template are complete.
   - If not, direct authors toward appropriate instructions.
@@ -29,7 +29,7 @@
 - Run automated tests: spelling, linting, etc ... will be filled in later.
 - For packages needing continuous integration on multiple platforms ([criteria in this section of the packaging chapter](../authoring/overview#continuous-integration)), make sure the package gets tested on multiple platforms (having the package built on both Travis and AppVeyor for instance).
 - Wherever possible when asking for changes, direct authors to automatic tools and online resources.
-- If the package raises a new issue for pyOpenSci policy, create an issue on [pyOpenSci's governance repo](https://github.com/pyOpenSci/governance)
+- If the package raises a new issue for pyOpenSci policy, create an issue on [pyOpenSci's governance repo](https://github.com/pyOpenSci/governance/issues/new)
 
 ## Guidelines For Identifying Reviewers
 
@@ -55,7 +55,7 @@ Here are criteria to keep in mind when choosing a reviewer. You might need to pi
 * Has not reviewed a package for us within the last 6 months.
 * Some package development experience.
 * Some domain experience in the field of the package or data source.
-* No [conflicts of interest](peer_review_proc#conflict-of-interest).
+* No [conflicts of interest](../open-source-software-peer-review/policies-and-guidelines#conflict-of-interest).
 * Try to balance your sense of the potential reviewer’s experience against the complexity of the package.
 * Diversity - with two reviewers both shouldn’t be cis white males.
 * Some evidence that they are interested in openness or Python community activities, although blind emailing is fine.
@@ -67,13 +67,13 @@ Each submission should be reviewed by _two_ package reviewers. Although it is fi
 -   Check in with reviewers and authors occasionally. Offer clarification and help as needed.
 -   In general aim for 3 weeks for review, 2 weeks for subsequent changes, and 1 week for reviewer approval of changes.
 -   Upon all reviews being submitted, change the review status tag to `4/review-in-awaiting-changes` to update the reminder bot.
--   If the author stops responding, refer to [the policies](peer_review_proc#review-process-guidelines) and/or ping the other editors in the Slack channel for discussion. Importantly, if a reviewer was assigned to a closed issue, contact them when closing the issue to explain the decision, thank them once again for their work, and make a note in our database to assign them to a submission with high chances of smooth software review next time (e.g. a package author who has already submitted packages to us).
+-   If the author stops responding, refer to [the policies](open-source-software-peer-review/policies-and-guidelines.html#review-process-guidelines) and/or ping the other editors in the Slack channel for discussion. Importantly, if a reviewer was assigned to a closed issue, contact them when closing the issue to explain the decision, thank them once again for their work, and make a note in our database to assign them to a submission with high chances of smooth software review next time (e.g. a package author who has already submitted packages to us).
 -   Upon changes being made, change the review status tag to `5/awaiting-reviewer-response`.
 
 ### Editor Responsibilities After Review:
 
 -   Change the status tag to `6/approved`.
--   You can use the [approval comment template](../appendices/templates#approval-comment-template).
+-   You can use the [approval comment template](../appendices/templates#editor-approval-comment-template).
 -   Add review/er information to the review database.
 -   If package will be migrated to `pyOpenSci`:
     -   Create a two-person team in pyOpenSci's "pyOpenSci" GitHub organization, named for the package, with yourself and the package author as members.

--- a/open-source-software-submissions/reviewer-guide.md
+++ b/open-source-software-submissions/reviewer-guide.md
@@ -78,12 +78,12 @@ your reviews do not need to be as long as these examples):
 
 You can read blog posts written by reviewers about their experiences [via this link](https://ropensci.org/tags/reviewer/). In particular, in [this blog post by Mara Averick](https://ropensci.org/blog/2017/08/22/first-package-review/) read about the "naive user" role a reviewer can take to provide useful feedback even without being experts of the package's topic or implementation, by asking themselves _"What did I think this thing would do? Does it do it? What are things that scare me off?"_. In [another blog post](https://ropensci.org/blog/2017/09/08/first-review-experiences/) Verena Haunschmid explains how she alternated between using the package and checking its code.
 
-As both a former reviewer and package author [Adam Sparks](https://adamhsparks.github.io/) [wrote this](https://twitter.com/adamhsparks/status/898132036451303425) "[write] a good critique of the package structure and best coding practices. If you know how to do something better, tell me. It’s easy to miss documentation opportunities as a developer, as a reviewer, you have a different view. You’re a user that can give feedback. What’s not clear in the package? How can it be made more clear? If you’re using it for the first time, is it easy? Do you know another R package that maybe I should be using? Or is there one I’m using that perhaps I shouldn’t be? If you can contribute to the package, offer."
+As both a former reviewer and package author [Adam Sparks](https://adamhsparks.com) [wrote this](https://twitter.com/adamhsparks/status/898132036451303425) "[write] a good critique of the package structure and best coding practices. If you know how to do something better, tell me. It’s easy to miss documentation opportunities as a developer, as a reviewer, you have a different view. You’re a user that can give feedback. What’s not clear in the package? How can it be made more clear? If you’re using it for the first time, is it easy? Do you know another R package that maybe I should be using? Or is there one I’m using that perhaps I shouldn’t be? If you can contribute to the package, offer."
 
 
 ### Feedback on the Process
 
-We welcome any feedback and/or questions about the review process! We encourage you to open an issue on our [governance repository](https://github.com/pyOpenSci/governance).
+We welcome any feedback and/or questions about the review process! We encourage you to open an issue on our [governance repository](https://github.com/pyOpenSci/governance/issues/new).
 
 ## Submitting the Review
 - When your review is complete, paste it as a comment into the package software-review issue.


### PR DESCRIPTION
There appears to be a number of outdated URLs in the contributing guide. This PR should fix them.