### PR TITLE
ORG: unnest peer review subsections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,22 @@ To build the guide locally, take the following steps:
 * Install Jupyter Book
 
   ```
-  pip install -U "jupyter-book>=0.7.0b"
+  pip install -U jupyter-book
 
   ```
 * Build the guide
 
   ```
   # Cd to the repo if you are not already in it!
-  cd contributing-guide
+  $ cd contributing-guide
   # Build the book locally!
-  jupyter-book build .
+  $ jupyter-book build .
+  ```
+
+  To clean out old pages of your book:
+
+  ```
+  $ jupyter-book clean .
   ```
 
 ## Contributing to this guide

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,23 +1,21 @@
-- file: intro
-
-- part: Overview
+format: jb-book
+root: intro
+parts:
+- caption: Overview
   chapters:
   - file: open-source-software-peer-review/intro
-    sections:
-    - file: open-source-software-peer-review/aims-and-scope
-    - file: open-source-software-peer-review/code-of-conduct
-    - file: open-source-software-peer-review/policies-and-guidelines
-
-- part: Submission Guides
+  - file: open-source-software-peer-review/aims-and-scope
+  - file: open-source-software-peer-review/code-of-conduct
+  - file: open-source-software-peer-review/policies-and-guidelines
+- caption: Open Peer Review Guides
   chapters:
   - file: open-source-software-submissions/intro
-    sections:
-    - file: open-source-software-submissions/author-guide
-    - file: open-source-software-submissions/reviewer-guide
-    - file: open-source-software-submissions/editors-guide
-    - file: open-source-software-submissions/editor-in-chief-guide
-
-- part: Python Packaging Guide
+    title: Peer Review Process
+  - file: open-source-software-submissions/author-guide
+  - file: open-source-software-submissions/reviewer-guide
+  - file: open-source-software-submissions/editors-guide
+  - file: open-source-software-submissions/editor-in-chief-guide
+- caption: Python Packaging Guide
   chapters:
   - file: authoring/index
     sections:
@@ -26,7 +24,7 @@
     - file: authoring/tools-for-developers
     - file: authoring/testing
     - file: authoring/release
-- part: Appendices
+- caption: Appendices
   chapters:
   - file: appendices/templates
   - file: appendices/glossary

--- a/open-source-software-submissions/intro.md
+++ b/open-source-software-submissions/intro.md
@@ -1,4 +1,4 @@
-# Get Involved with PyOpenSci
+# An Overview Of the Peer Review Process
 
 Welcome to PyOpenSci submissions. Below, you will find a collection of guides
 that will direct you through the peer review process.


### PR DESCRIPTION
This PR just unnests sections so they are more visible in the guide. i haven't edited any content. 
This stems from feedback from @kcranston and @xmnlab  
the new TOC will look like this: 

<img width="307" alt="Screen Shot 2022-09-19 at 5 24 21 PM" src="https://user-images.githubusercontent.com/7649194/191136165-8fc4de6b-4124-4930-a9ec-44cf3de5e676.png">
