### PR TITLE
CONTENT: Update policies for peer review

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -3,7 +3,8 @@ root: intro
 parts:
 - caption: About Our Peer Review Process
   chapters:
-#  - file: open-source-software-peer-review/intro
+  - file: open-source-software-peer-review/intro
+    title: About our peer review process
   - file: open-source-software-peer-review/aims-and-scope
     title: Peer Review Goals and Scope
   - file: open-source-software-peer-review/policies-and-guidelines

--- a/open-source-software-peer-review/aims-and-scope.md
+++ b/open-source-software-peer-review/aims-and-scope.md
@@ -4,7 +4,7 @@ pyOpenSci has several goals to support the scientific Python open source
 community.
 
 1. **Packages with overlapping functionality:** 
-It's easy to find multiple packages on PyPi that perform that same tasks (or overlapping tasks). When you submit to us, we ask that you know about other packages in our system that may do similar things. This check will help us connect maintainers who are working on similar goals. It will also help us in the long term reduce the number of overlapping packages, in various states of maintainence on pypi.
+It's easy to find multiple packages on `PyPI` that perform that same tasks (or overlapping tasks). When you submit to us, we ask that you know about other packages in our system that may do similar things. This check will help us connect maintainers who are working on similar goals. It will also help us in the long term reduce the number of overlapping packages, in various states of maintenance on `PyPI`.
 
 2. **Improve package usability:** Documentation makes it easier for scientists to use your tools. Our review process looks at documentation, quick start vignettes (code samples to get started) to make it easier for new users to get started using your package. 
 
@@ -35,7 +35,7 @@ whether it is in scope or not.
 
 ## Package Overlap
 pyOpenSci encourages competition among packages, forking and re-implementation 
-as they improve options of users. However, strive to make packages in the 
+as they improve options of users. However, we strive to make packages in the 
 pyOpenSci suite to represent our top recommendations for the tasks that they 
 perform. We aim to avoid duplication of functionality of existing Python 
 packages in any repo without significant improvements. A Python package that 
@@ -55,7 +55,7 @@ following our package guidelines while others do not, unless this leads to a
 significant difference in the areas above.
 
 We recommend that packages highlight differences from and improvements over 
-overlapping packages in their README and/or vignettes.
+overlapping packages in their `README` and/or vignettes or get started tutorials.
 
 We encourage developers whose packages are not accepted due to overlap to still 
 consider submittal to other repositories or journals.

--- a/open-source-software-peer-review/intro.md
+++ b/open-source-software-peer-review/intro.md
@@ -3,9 +3,30 @@
 ```{tableofcontents}
 ```
 
-## Why do we need pyOpenSci
+## Why do we need pyOpenSci peer review?
 
-Discussion here on 
+The open peer review process lead by pyOpenSci address several issues in the scientific Python
+ecosystem:
+
+1. [Multiple packages that have overlapping functionality. See this example on `PyPI`](https://pypi.org/search/?q=twitter) 
+2. Packages that have varying levels of maintenance yet are used by the community to support open science workflows. 
+3. Packages that are well-maintained and used but then maintenance comes to a halt when the maintainer needs to step down (burn-out is common and understandable).
+4. Packages using varying types of packaging and documentation approaches making it more difficult to contribute.
+5. Packages that are not documented enough to support:
+   * Contributions from others
+   * Directions on how to get started using the package functionality (quick start vignettes or tutorials)  
+* Packages that are missing OSI licensing and citation information
+
+### How is pyOpenSci different from JOSS and other review processes?
+pyOpenSci is different from other review processes
+out there because:
+
+1. We specifically review to community accepted python packaging standards
+2. We consider accepted packages as vetted and a part of our ecosystem. We recommend those packages to others. If the maintainer needs to step down, we will ensure a new maintainer takes over OR sunset and remove the package from our ecosystem.
+
+The JOSS review process is about publication. There, you will receive a DOI that is cross-ref
+enabled. However JOSS will not followup with the maintainer to ensure that the package is maintained over time. 
+
 
 ## Why submit your package to pyOpenSci for review?
 
@@ -15,7 +36,6 @@ But of course, before you submit, please be sure to read the policies
 
 First, and foremost, we hope you submit your package for review **because you value the feedback**.  We aim to provide useful feedback to package authors and for our review process to be open, non-adversarial, and focused on improving software quality.
 
-
 - Once your package is accepted, your package will receive **support from pyOpenSci members**. You'll retain ownership and control of your package. However, if you need help with ongoing maintenance issues, we will try to find people who can help. 
   
 -  pyOpenSci will **promote your package** through our:
@@ -23,7 +43,7 @@ First, and foremost, we hope you submit your package for review **because you va
    - [blog](https://wwwpyopensci.org/blog/), and 
    - [social media account](https://twitter.com/pyopensci).
 
--   pyOpenSci packages that are in scope for the [Journal of Open-Source Software](https://joss.theoj.org/) and add the necessary accompanying short `paper.md` file, can, at the discretion of JOSS editors, benefit from a fast-tracked review process. <LINK TO MORE ON THIS>
+-   pyOpenSci packages that are in scope for the [Journal of Open-Source Software](https://joss.theoj.org/) and add the necessary accompanying short `paper.md` file, can, at the discretion of JOSS editors, benefit from a fast-tracked review process. [Read more about our partnership with JOSS here](#pyopensci-and-joss).
 
 ## Why do we need peer review for Python scientific software?
 
@@ -76,8 +96,10 @@ our review process.
 
 Each package review is contained within an issue in the [pyOpenSci/software-review GitHub repository](https://github.com/pyopensci/software-review/). 
 
-# TODO: ADD GOOD EXAMPLE HERE
-For instance, click [here](https://github.com/ropensci/software-review/issues/24) to read the review thread of the `ropenaq` package: the process is an ongoing conversation until acceptance of the package, with two external reviews as important milestones. 
+
+```{note}
+For instance, click [here](https://github.com/ropensci/software-review/issues/24) to read the review thread from an rOpenSci review of the `ropenaq` package. Note that the  process is an ongoing conversation until the package is accepted. Two external reviews are important milestones in the review process. 
+```
 
 ### GitHub tools including issue submission templates and labels help us streamline peer review
 We use GitHub features including:
@@ -133,12 +155,9 @@ API wrappers. JOSS will then accept our review (you will not need a second
 review with JOSS!). JOSS will review your paper and you will get a JOSS badge 
 to add next to your pyOpenSci badge of review. And a cross-ref enabled DOI.
 
-<TODO: add link
-Read more here on the JOSS / pyOpenSci partnership
 
 ## pyOpenSci and JOSS
-(is this the right place for this? - this probably should go in the reviewer 
-guide and make it super short here)
+
 > You don't have to chose between pyOpenSci and JOSS; You can submit your package to both.
 
 pyOpenSci and [the Journal of Open Source Software (JOSS)](https://joss.theoj.org/)
@@ -165,4 +184,3 @@ the pyOpenSci review process is different from that of JOSS in a few ways:
 JOSS reviews are [more limited in scope](https://joss.readthedocs.io/en/latest/review_criteria.html) compared to pyOpenSci and the
 [submission criteria](https://joss.readthedocs.io/en/latest/review_criteria.html)
 are, in places, less stringent than those of pyOpenSci.
-

--- a/open-source-software-peer-review/intro.md
+++ b/open-source-software-peer-review/intro.md
@@ -1,10 +1,104 @@
 # How Peer Review Works
 
-
-
-
 ```{tableofcontents}
 ```
+
+## Why do we need peer review for Python scientific software?
+
+pyOpenSci's [suite of packages](https://pyopensci.org/python-packages/) are fully 
+contributed by community members with a great diversity of skills. This diversity 
+of developer backgrounds results in a range of quality associated with the suite 
+of tools available to process scientific data.
+
+### Peer review helps maintain consistent open source software quality
+
+Peer review of python tools that support science is critical to enforcing 
+quality and usability standards. All pyOpenSci packages contributed by the 
+community undergo a transparent, constructive, non adversarial and open peer 
+review process. The goal of that process is to enforce commonly accepted standards.
+These standards include technical structure of the package, usability of the 
+package, documenting package functionality in a way that is accessible 
+to all levels of users and proper licensing and citation information. 
+
+### A truly community-founded review process
+
+Our peer review process is run by volunteer members of the Python scientific 
+community:
+
+* Editors manage the incoming package review submissions and ensure 
+reviews move forward progress of submissions; 
+* authors create, submit and improve their package; 
+* Reviewers, two per submission, examine the software code and user experience. 
+
+```{note}
+[This blog post](https://www.numfocus.org/blog/how-ropensci-uses-code-review-to-promote-reproducible-science/) written by editors from our partner organization, rOpenSci, is a good introduction to pyOpenSci software peer review 
+```
+### How do I know a python package is pyOpenSci vetted?
+
+You can identify pyOpenSci packages that have been peer-reviewed by the green 
+"peer-reviewed" badge at the top their README, [![pyOpenSci](https://tinyurl.com/y22nb8up)]() linking to the specific issue
+where the tool was reviewed. [See this example from devicely, one of our packages](https://github.com/hpi-dhc/devicely).
+
+### How do reviews work?
+
+We use GitHub for our entire review process. We like GitHub because:
+
+* It's free to create an account
+* It facilitates collaboration and supports community around a package
+* It facilitates open discussion via issues
+* It supports version control
+* Numerous packages store their code bases on GitHub
+
+We make the most of [GitHub](https://github.com/)infrastructure in
+our review process.
+
+Each package review is contained within an issue in the [pyPpenSci/software-review GitHub repository](https://github.com/pyopensci/software-review/). 
+
+# TODO: ADD GOOD EXAMPLE HERE
+For instance, click [here](https://github.com/ropensci/software-review/issues/24) to read the review thread of the `ropenaq` package: the process is an ongoing conversation until acceptance of the package, with two external reviews as important milestones. 
+
+### GitHub tools including issue submission templates and labels helps us streamline peer review
+We use GitHub features including:
+
+* issue templates (as submission templates), and
+* labelling issues to track progress of submissions (from editor checks to approval).
+* Project boards to track help wanted items
+
+ALl of this functionality supports a streamlined and open peer review
+process. 
+
+## Why submit your package to pyOpenSci?
+
+-   First, and foremost, we hope you submit your package for review **because you value the feedback**.  We aim to provide useful feedback to package authors and for our review process to be open, non-adversarial, and focused on improving software quality.
+-   Once aboard, your package will continue to receive **support from rOpenSci members**.  You'll retain ownership and control of your package, but we can help with ongoing maintenance issues such as those associated with updates to R and dependencies and CRAN policies.
+-   rOpenSci will **promote your package** through our [webpage](https://ropensci.org/packages/), [blog](https://ropensci.org/blog/), and [social media](https://twitter.com/ropensci). Packages in our suite also get a [documentation website that is automatically built and deployed after each push](#docsropensci).
+-   rOpenSci **packages can be cross-listed** with other repositories such as CRAN and BioConductor.
+-   rOpenSci packages that are in scope for the [Journal of Open-Source Software](https://joss.theoj.org/) and add the necessary accompanying short paper, would, at the discretion of JOSS editors, benefit from a fast-tracked review process.
+-   If you write one, rOpenSci will **promote gitbooks related to your package**: the source of such books can be transferred to [the `ropensci-books` GitHub organisation](https://github.com/ropensci-books) for books to be listed [at books.ropensci.org](https://books.ropensci.org/).
+
+## Why review packages for rOpenSci? {#whyreview}
+
+-   As in any peer-review process, we hope you choose to review **to give back to the rOpenSci and scientific communities.**  Our mission to expand access to scientific data and promote a culture of reproducible research is only possible through the volunteer efforts of community members like you.
+-   Review is a two-way conversation. By reviewing packages, you'll have the chance to **continue to learn development practices from authors and other reviewers**.
+-   The open nature of our review process allows you to **network and meet colleagues and collaborators** through the review process. Our community is friendly and filled with supportive members expert in R development and many other areas of science and scientific computing.
+-   To volunteer to be one of our reviewers, fill out [this short form](https://airtable.com/shrnfDI2S9uuyxtDw) providing your contact information and areas of expertise. We are always looking for more reviewers with both general package-writing experience and domain expertise in the fields where packages are used.
+
+
+## Why are reviews open? {#whyopen}
+
+Our reviewing threads are public. Authors, reviewers, and editors all know each other’s identities. The broader community can view or even participate in the conversation as it happens. This provides an incentive to be thorough and provide non-adversarial, constructive reviews. Both authors and [reviewers report](https://ropensci.org/tags/reviewer/) that they enjoy and learn more from this open and direct exchange. It also has the benefit of building a community. Participants have the opportunity to meaningfully network with new peers, and new collaborations have emerged via ideas spawned during the review process.
+
+We are aware that open systems can have drawbacks. For instance, in traditional academic review, [double-blind peer review can increase representation of female authors](https://www.sciencedirect.com/science/article/pii/S0169534707002704), suggesting bias in non-blind reviews. It is also possible reviewers are less critical in open review. However, we posit that the openness of the review conversation provides a check on review quality and bias; it’s harder to inject unsupported or subjective comments in public and without the cover of anonymity. Ultimately, we believe that having direct and public communication between authors and reviewers improves quality and fairness of reviews.
+
+Furthermore, authors and reviewers have the ability to contact privately the editors if they have any doubt or question.
+
+## How will users know a package has been reviewed?
+
+* Your package README will feature a peer-review badge linking to the software review thread.
+* Your package will get a [`docs.ropensci.org` docs website](#rodocsci) that you can link from DESCRIPTION.
+* Your package repo will be transferred to the rOpenSci organization.
+* If reviewers [agree to be listed in DESCRIPTION](#authorship), their metadata will mention the review.
+
 
 
 

--- a/open-source-software-peer-review/intro.md
+++ b/open-source-software-peer-review/intro.md
@@ -3,6 +3,28 @@
 ```{tableofcontents}
 ```
 
+## Why do we need pyOpenSci
+
+Discussion here on 
+
+## Why submit your package to pyOpenSci for review?
+
+There is a lot to gain from submitting your package to pyOpenSci.
+But of course, before you submit, please be sure to read the policies 
+... to ensure pyOpenSci is the right fit for you. 
+
+First, and foremost, we hope you submit your package for review **because you value the feedback**.  We aim to provide useful feedback to package authors and for our review process to be open, non-adversarial, and focused on improving software quality.
+
+
+- Once your package is accepted, your package will receive **support from pyOpenSci members**. You'll retain ownership and control of your package. However, if you need help with ongoing maintenance issues, we will try to find people who can help. 
+  
+-  pyOpenSci will **promote your package** through our:
+   - [webpage](https://pyopensci.org/python-packages/), 
+   - [blog](https://wwwpyopensci.org/blog/), and 
+   - [social media account](https://twitter.com/pyopensci).
+
+-   pyOpenSci packages that are in scope for the [Journal of Open-Source Software](https://joss.theoj.org/) and add the necessary accompanying short `paper.md` file, can, at the discretion of JOSS editors, benefit from a fast-tracked review process. <LINK TO MORE ON THIS>
+
 ## Why do we need peer review for Python scientific software?
 
 pyOpenSci's [suite of packages](https://pyopensci.org/python-packages/) are fully 
@@ -52,56 +74,54 @@ We use GitHub for our entire review process. We like GitHub because:
 We make the most of [GitHub](https://github.com/)infrastructure in
 our review process.
 
-Each package review is contained within an issue in the [pyPpenSci/software-review GitHub repository](https://github.com/pyopensci/software-review/). 
+Each package review is contained within an issue in the [pyOpenSci/software-review GitHub repository](https://github.com/pyopensci/software-review/). 
 
 # TODO: ADD GOOD EXAMPLE HERE
 For instance, click [here](https://github.com/ropensci/software-review/issues/24) to read the review thread of the `ropenaq` package: the process is an ongoing conversation until acceptance of the package, with two external reviews as important milestones. 
 
-### GitHub tools including issue submission templates and labels helps us streamline peer review
+### GitHub tools including issue submission templates and labels help us streamline peer review
 We use GitHub features including:
 
 * issue templates (as submission templates), and
 * labelling issues to track progress of submissions (from editor checks to approval).
 * Project boards to track help wanted items
 
-ALl of this functionality supports a streamlined and open peer review
+All of this functionality supports a streamlined and open peer review
 process. 
 
-## Why submit your package to pyOpenSci?
+## Why review a package for pyOpenSci?
 
--   First, and foremost, we hope you submit your package for review **because you value the feedback**.  We aim to provide useful feedback to package authors and for our review process to be open, non-adversarial, and focused on improving software quality.
--   Once aboard, your package will continue to receive **support from rOpenSci members**.  You'll retain ownership and control of your package, but we can help with ongoing maintenance issues such as those associated with updates to R and dependencies and CRAN policies.
--   rOpenSci will **promote your package** through our [webpage](https://ropensci.org/packages/), [blog](https://ropensci.org/blog/), and [social media](https://twitter.com/ropensci). Packages in our suite also get a [documentation website that is automatically built and deployed after each push](#docsropensci).
--   rOpenSci **packages can be cross-listed** with other repositories such as CRAN and BioConductor.
--   rOpenSci packages that are in scope for the [Journal of Open-Source Software](https://joss.theoj.org/) and add the necessary accompanying short paper, would, at the discretion of JOSS editors, benefit from a fast-tracked review process.
--   If you write one, rOpenSci will **promote gitbooks related to your package**: the source of such books can be transferred to [the `ropensci-books` GitHub organisation](https://github.com/ropensci-books) for books to be listed [at books.ropensci.org](https://books.ropensci.org/).
+We hope you choose to review **to give back to the rOpenSci and scientific communities.**  Our mission to expand the ability to efficiently use scientific data and promote a culture of open reproducible is only possible through the volunteer efforts of community members like you.
 
-## Why review packages for rOpenSci? {#whyreview}
+-   Peer review is a two-way conversation. By reviewing packages, you'll have the chance to **continue to learn development practices from authors and other reviewers**.
+-   The open nature of our review process allows you to **network and meet colleagues and collaborators** through the review process. Our community is friendly and filled with supportive members expert in Python package development, a diversity of science domains and computer science.
 
--   As in any peer-review process, we hope you choose to review **to give back to the rOpenSci and scientific communities.**  Our mission to expand access to scientific data and promote a culture of reproducible research is only possible through the volunteer efforts of community members like you.
--   Review is a two-way conversation. By reviewing packages, you'll have the chance to **continue to learn development practices from authors and other reviewers**.
--   The open nature of our review process allows you to **network and meet colleagues and collaborators** through the review process. Our community is friendly and filled with supportive members expert in R development and many other areas of science and scientific computing.
--   To volunteer to be one of our reviewers, fill out [this short form](https://airtable.com/shrnfDI2S9uuyxtDw) providing your contact information and areas of expertise. We are always looking for more reviewers with both general package-writing experience and domain expertise in the fields where packages are used.
+### Volunteer to review for us
+-   To volunteer to be one of our reviewers, fill out [this short form](https://forms.gle/9dv99gri6XKNU8177). In the form you will provide your contact information and areas of expertise. We are always looking for more reviewers with both general package-writing experience and domain expertise in the fields where packages are used. Some of our reviewers focus on package usability and documentation. This allows you to review even if you don't have strong technical background. We will pair you with a second reviewer that can focus more on the technical aspect of the review. 
 
+## Why are reviews open?
 
-## Why are reviews open? {#whyopen}
+Our reviewing threads are public. Authors, reviewers, and editors all know 
+each other’s identities. The broader community can view or even participate 
+in the conversation as it happens. This provides an incentive to be thorough 
+and provide non-adversarial, constructive reviews. 
 
-Our reviewing threads are public. Authors, reviewers, and editors all know each other’s identities. The broader community can view or even participate in the conversation as it happens. This provides an incentive to be thorough and provide non-adversarial, constructive reviews. Both authors and [reviewers report](https://ropensci.org/tags/reviewer/) that they enjoy and learn more from this open and direct exchange. It also has the benefit of building a community. Participants have the opportunity to meaningfully network with new peers, and new collaborations have emerged via ideas spawned during the review process.
+It also has the benefit of building a community. Participants have the 
+opportunity to meaningfully network with new peers, and new collaborations 
+have emerged via ideas spawned during the review process.
 
-We are aware that open systems can have drawbacks. For instance, in traditional academic review, [double-blind peer review can increase representation of female authors](https://www.sciencedirect.com/science/article/pii/S0169534707002704), suggesting bias in non-blind reviews. It is also possible reviewers are less critical in open review. However, we posit that the openness of the review conversation provides a check on review quality and bias; it’s harder to inject unsupported or subjective comments in public and without the cover of anonymity. Ultimately, we believe that having direct and public communication between authors and reviewers improves quality and fairness of reviews.
+We are aware that open systems can have drawbacks. For instance, in 
+traditional academic review, [double-blind peer review can increase representation of female authors](https://www.sciencedirect.com/science/article/pii/S0169534707002704), 
+suggesting bias in non-blind reviews. 
 
-Furthermore, authors and reviewers have the ability to contact privately the editors if they have any doubt or question.
+It is also possible reviewers are less critical in open review. However, we 
+believe that the openness of the review conversation provides a check on 
+review quality and bias; it’s harder to inject unsupported or subjective 
+comments in public and without the cover of anonymity. 
 
-## How will users know a package has been reviewed?
-
-* Your package README will feature a peer-review badge linking to the software review thread.
-* Your package will get a [`docs.ropensci.org` docs website](#rodocsci) that you can link from DESCRIPTION.
-* Your package repo will be transferred to the rOpenSci organization.
-* If reviewers [agree to be listed in DESCRIPTION](#authorship), their metadata will mention the review.
-
-
-
-
+> Ultimately, we 
+> believe that having direct and public communication between authors and 
+> reviewers improves quality and fairness of reviews.
 
 
 ### If you submit to pyOpenSci You Can Also Be Accepted by JOSS
@@ -115,7 +135,6 @@ to add next to your pyOpenSci badge of review. And a cross-ref enabled DOI.
 
 <TODO: add link
 Read more here on the JOSS / pyOpenSci partnership
-
 
 ## pyOpenSci and JOSS
 (is this the right place for this? - this probably should go in the reviewer 

--- a/open-source-software-peer-review/policies-and-guidelines.md
+++ b/open-source-software-peer-review/policies-and-guidelines.md
@@ -28,7 +28,32 @@
   new submission. If the package is still in scope, the author will have to respond to
   the initial reviews before the editor starts looking for new reviewers.
 
-### Conflict of interest
+## Submitting your package for review in other venues
+
+We strongly suggest submitting your package for review with pyOpenSci before:
+ 
+*  publishing on pypi or conda; 
+*  submitting a software paper describing the package to a journal. 
+ 
+Review feedback may result in major improvements and updates to your package, 
+including changes that could be break package functionality. 
+
+We do not consider previous publication on `PyPI` or `conda` or in other venues 
+sufficient reason to not adopt reviewer or editor recommendations provided in 
+our review.
+
+> Do not submit your package for review while it or an associated manuscript is 
+> also under review at another venue, as this may result on conflicting requests 
+> for changes from two sets of reviewers.
+
+### Publication with Journal of Open Source Software (JOSS)
+If you have previously published your software package with JOSS, you can still
+submit it to pyOpenSci for review. This provides:
+
+* Increased visibility of your package as a vetted tool within the scientific python ecosystem
+* We will also keep in touch with you as a maintainer to support long term maintenance. If you need to step down from maintaining your package we will help find a new maintainer and/or help sunset the tool.
+
+### Conflict of interest for reviews and editors
 Following criteria are meant to be a guide for what constitutes a conflict of interest
 for an editor or reviewer. The potential editor or reviewer has a conflict of interest
 if:
@@ -42,14 +67,33 @@ if:
 - The potential reviewer/editor has significantly contributed to a competitor project.
 - There is also a lifetime COI for the family members, business partners, and thesis student/advisor or mentor.
 
-In the case where none of the associate editors can serve as editor, an external guest editor will be recruited.
+In the case where none of the associate editors can serve as editor, an 
+external guest editor will be recruited to lead the package review.
 
 ## After Acceptance: Package Ownership and Maintenance
 
-Authors of contributed packages essentially maintain the same ownership they had prior
-to their package joining the pyOpenSci suite. Package authors will continue to maintain
+Authors of contributed packages essentially maintain the same ownership they 
+had prior to their package joining the pyOpenSci suite. Package authors will 
+continue to maintain
 and develop their software after acceptance into pyOpenSci. Unless explicitly added as
-collaborators, the pyOpenSci team will not interfere much with day to day operations.
+collaborators, the pyOpenSci team will not interfere with day to day operations.
+
+If you need to step down from maintaining your accepted pyOpenSci package, please
+please notify the EiC / software review lead of this as soon as you can. We 
+will talk with you about your tool and work together to either find a new maintainer or sunset the tool depending upon what makes the most sense. 
+
+We will reach out to our package maintainers each year to check in on how 
+maintenance is going. 
+
+### Maintainer Responsiveness
+If package maintainers do not respond in a timely manner to requests for package fixes,
+we will remind the maintainer a number of times. After 3 months (or shorter time
+frame, depending on how critical the fix is) we will discuss the future of the package
+as a part of our pyOpenSci ecosystem.
+
+Should authors abandon the maintenance of an actively used package in our suite, 
+we will consider petitioning PyPI to transfer package maintainer status to pyOpenSci.
+
 
 ```{note}
 Note from the Executive Director: Please note that we are reviewing the text 
@@ -69,14 +113,7 @@ of individual maintainers. Buggy, unmaintained software may be removed from our 
 any time. We also ask maintainers that they get in touch with us if they do need 
 to step down from maintaining a tool. 
 
-### Maintainer Responsiveness
-If package maintainers do not respond in a timely manner to requests for package fixes,
-we will remind the maintainer a number of times. After 3 months (or shorter time
-frame, depending on how critical the fix is) we will discuss the future of the package
-as a part of our pyOpenSci ecosystem.
 
-Should authors abandon the maintenance of an actively used package in our suite, 
-we will consider petitioning PyPI to transfer package maintainer status to pyOpenSci.
 
 ### Requesting Package Removal
 In the unlikely scenario that a contributor of a package requests removal of their

--- a/open-source-software-peer-review/policies-guidelines.md
+++ b/open-source-software-peer-review/policies-guidelines.md
@@ -9,7 +9,7 @@
 - Once all major issues and questions, and those addressable with reasonable effort, are
   resolved, the editor assigned to a package will make a decision (accept, hold, or
   reject). Rejections are usually done early (before the review process begins, see the
-  aims and scope section). In rare cases a package may also not be onboarded after
+  aims and scope section). In rare cases a package may also not be on-boarded after
   review & revision. It is ultimately editor’s decision on whether or not to reject the
   package based on how the reviews are addressed.
 - Communication between authors, reviewers and editors will first and foremost take
@@ -32,7 +32,7 @@
 
 We strongly suggest submitting your package for review with pyOpenSci before:
  
-*  publishing on pypi or conda; 
+*  publishing on `PyPI` or `conda`; 
 *  submitting a software paper describing the package to a journal. 
  
 Review feedback may result in major improvements and updates to your package, 
@@ -42,7 +42,7 @@ We do not consider previous publication on `PyPI` or `conda` or in other venues
 sufficient reason to not adopt reviewer or editor recommendations provided in 
 our review.
 
-> Do not submit your package for review while it or an associated manuscript is 
+>Please do not submit your package for review while it or an associated manuscript is 
 > also under review at another venue, as this may result on conflicting requests 
 > for changes from two sets of reviewers.
 

--- a/open-source-software-peer-review/policies-guidelines.md
+++ b/open-source-software-peer-review/policies-guidelines.md
@@ -9,7 +9,7 @@
 - Once all major issues and questions, and those addressable with reasonable effort, are
   resolved, the editor assigned to a package will make a decision (accept, hold, or
   reject). Rejections are usually done early (before the review process begins, see the
-  aims and scope section), but in rare cases a package may also be not onboarded after
+  aims and scope section). In rare cases a package may also not be onboarded after
   review & revision. It is ultimately editor’s decision on whether or not to reject the
   package based on how the reviews are addressed.
 - Communication between authors, reviewers and editors will first and foremost take
@@ -86,13 +86,17 @@ We will reach out to our package maintainers each year to check in on how
 maintenance is going. 
 
 ### Maintainer Responsiveness
-If package maintainers do not respond in a timely manner to requests for package fixes,
-we will remind the maintainer a number of times. After 3 months (or shorter time
-frame, depending on how critical the fix is) we will discuss the future of the package
-as a part of our pyOpenSci ecosystem.
+If package maintainers do not respond in a timely manner to requests for 
+package fixes, we will remind the maintainer a number of times. After 3 months 
+(or shorter time frame, depending on how critical the fix is) we will discuss 
+the future of the package as a part of our pyOpenSci ecosystem. 
 
-Should authors abandon the maintenance of an actively used package in our suite, 
-we will consider petitioning PyPI to transfer package maintainer status to pyOpenSci.
+* If a package becomes completely un-maintained we will highlight that fact and 
+remove it as a vetted tool in our ecosystem.
+* If a sub-community decides to fork and maintain that package we are open to working with the new maintainers to keep the package within our ecosystem.
+
+<!-- Should authors abandon the maintenance of an actively used package in our suite, 
+we will consider petitioning PyPI to transfer package maintainer status to pyOpenSci. -->
 
 
 ```{note}

--- a/open-source-software-submissions/author-guide.md
+++ b/open-source-software-submissions/author-guide.md
@@ -1,9 +1,46 @@
 # pyOpenSci Review Guide for Python Open Source Package Authors
 
-So you are considering submitting a package for review with pyOpenSci? You've 
-come to the right place. 
+Are you considering submitting a package for review with pyOpenSci? You've 
+come to the right place!
 
-## 1. Does Your Package Meet Packaging Requirements?
+Below you will find the steps that you need to follow to submit a package 
+to pyOpenSci for peer review. 
+
+Before you begin this process, [please be sure to read the review process guidelines](../open-source-software-peer-review/policies-guidelines).
+
+## 1. Does your package have a 2-year maintenance plan?
+One of the goals of pyOpenSci is to maintain a curated list of 
+community-approved, maintained and vetted tools that support open science workflows. 
+
+As such we prefer to review packages that will be useful to the community
+and maintained over time. While we understand that burnout is real,
+and you may move on in the future to other projects, we ask that you commit
+to maintaining your package for at least 2 years. 
+
+If you need to step from maintaining your package, please let us know
+in advance. We will try to help you either.
+
+* Find a new maintainer to take over your project or
+* Sunset your package.
+
+If the package is sunsetted we will remove it from our curated list 
+of vetted tools. 
+
+### Who should submit the package for review?
+
+If you have a team of people maintaining your package, please be sure
+that the submitting author is the person who "owns" or leads that maintenance. That person will become the long term point of contact 
+for pyOpenSci.
+
+```{note}
+If your package is more of a tool to support a specific workflow that 
+either may not be maintained long term or that may be so specific that 
+it won't have a broad user base, you might consider submitting it 
+directly to the Journal of Open Source Software (JOSS). 
+```
+
+
+## 2. Does Your Package Meet Packaging Requirements?
 Before submitting your project for review with pyOpenSci, make sure that it
 follows the standards and guidelines outlined in the 
 [Python packaging guide](../authoring/index).
@@ -18,7 +55,7 @@ and add things like testing, documentation, and/or continuous integration. We're
 happy to help. Also check out the rest of our [Packaging Guide](../authoring/overview), which may help answer some of your questions about packaging your code.
 ```
 
-## 2. Is Your Package in Scope for pyOpenSci?
+## 3. Is Your Package in Scope for pyOpenSci?
 Next, check to see if your package falls into the scope of pyOpenSci. If you aren't 
 sure about whether your package fits within pyOpenSci's scope (below), submit
 a [presubmission inquiry issue on the software-review](https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=0%2Fpresubmission&template=presubmission-inquiry.md&title=)
@@ -34,12 +71,12 @@ up to a week.
 
 1. Please be sure that you have time to devote to making changes to your 
 package. You may get feedback from an editor and two reviewers. Changes could 
-take time. Please consider this before submitting to us.
+take time. Please consider this before submitting to us. You can read more about the timeline to make changes in our [peer review policies page](../open-source-software-peer-review/policies-guidelines).
 2. Peer review is lead by a diverse group of volunteer editors and reviewers. 
-Please be considerate when engaging with everyone online.  
+Please be considerate when engaging with everyone online. 
 ```
 
-## 3. Presubmission Questions
+## 4. Presubmission Questions
 
 If your package does not clearly fit within one of the categories outlined in
 our [scope](../open-source-software-peer-review/aims-and-scope), create
@@ -48,18 +85,18 @@ in our software-review repo. You can use the same issue template if you have
 other questions. An editor will get back to you in a few days to answer your
 questions and to help determine the fit.
 
-## 4. Submit Your Package for Peer Review
+## 5. Submit Your Package for Peer Review
 To submit your package for peer review, you can 
 open an issue in our [pyopensci/software-review repo](https://github.com/pyOpenSci/software-review/issues/new/choose/issues/new/choose)
 repository and fill out the [Submit Software for Review](https://github.com/pyOpenSci/software-review/issues/new?assignees=&labels=1%2Feditor-checks%2C+New+Submission%21&template=submit-software-for-review.md&title=) issue template. 
 
-## 5. Editor in Chief Reviews Package for Scope and Minimal Infrastructure Criteria
+## 6. Editor in Chief Reviews Package for Scope and Minimal Infrastructure Criteria
 Once the issue is opened, an editor will review your submission within 
 **2 weeks** and respond with next steps. The editor may request that you make updates
 to your package to meet minimal criteria before review. They also may reject your 
 package if it does not fall within our scope. 
 
-## 6. The Review Begins
+## 7. The Review Begins
 If your package meets minimal criteria for being 
 reviewed it may then be given to an editor with appropriate domain experience 
 to run the review. That editor will assign 2-3 reviewers to review your 
@@ -68,13 +105,13 @@ issue within **3 weeks**. Reviewers also can open issues in your package reposit
 We prefer issues that link back to the review as they document changes made to your 
 package that were triggered by our review process.
 
-## 7. Response to Reviews
+## 8. Response to Reviews
 You should respond to reviewers’ comments within **2 weeks** of the 
 last-submitted review. You can make updates to your package at any time. We 
 encourage ongoing conversations between authors and reviewers. See the 
 reviewing guide for more details.
 
-## 8. Acceptance into pyOpenSci
+## 9. Acceptance into pyOpenSci
 Once the reviewers are happy with changes that you've made to the package, the
 editor will review everything and accept your package into the pyOpenSci ecosystem.
 Congratulations! You are almost done!


### PR DESCRIPTION
This PR adds:

* More extensive policies around peer review
* More background on peer review and why it's important
* some language around maintainers and expected communication

This PR has grown a bit. 
I updated the authors guide to include a section on maintenance. i think it's important that these are not one-off submissions ... that long term maintenance is considered. and the submitting author needs to be around to communicate with us about the package... so it's different from a paper review in that sense.. because software is a living tool not a one off script. 

we will need to finesse and better define this language as we move forward but this is a start. The policies are also heavily updated... but some sections still need to be more fleshed out... 

While I think more work needs to happen on this section of the guide I am going to merge this so some processes are documented. And we can go back and add / update as needed. 