### PR TITLE
CI Tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build_book:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: cimg/python:3.9
     steps:
       - checkout
       - run:

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -1,3 +1,5 @@
+name: link-artifact
+
 # Run on pushes
 on:
   push:
@@ -16,3 +18,7 @@ jobs:
           artifact-path: 0/html/index.html
           circleci-jobs: build_book
           job-title: Check rendered book here
+      - name: Check the URL
+        if: github.event.status != 'pending'
+        run: |
+          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -1,5 +1,3 @@
-name: artifact-redirector
-
 # Run on pushes
 on:
   push:

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   circleci_artifacts_redirector_job:
-    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -1,4 +1,4 @@
-name: link-artifact
+name: Book Preview
 
 # Run on pushes
 on:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   circleci_artifacts_redirector_job:
+    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -1,10 +1,6 @@
 name: Book Preview
 
-# Run on pushes
-on:
-  push:
-    branches:
-      - '*'
+on: [status]
 
 jobs:
   circleci_artifacts_redirector_job:
@@ -18,7 +14,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/html/index.html
           circleci-jobs: build_book
-          job-title: Check rendered book here
+          job-title: Click to preview rendered book
       - name: Check the URL
         if: github.event.status != 'pending'
         run: |

--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -12,6 +12,7 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
+        id: step1
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,4 +1,10 @@
-on: [status]
+name: artifact-redirector
+
+# Run on pushes
+on:
+  push:
+    branches:
+      - '*'
 
 jobs:
   circleci_artifacts_redirector_job:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
-    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -10,3 +10,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/html/index.html
+          circleci-jobs: build_book
+          job-title: Check rendered book here

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
+    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,6 +1,6 @@
 name: deploy-book
 
-# Only run this when the main branch changes
+# Run on pushes
 on:
   push:
     branches:
@@ -29,11 +29,19 @@ jobs:
       run: |
         jupyter-book build .
 
+    # Save html as artifact
+    - name: Save book html as artifact for viewing
+      uses: actions/upload-artifact@v3
+      with:
+        name: book-html
+        path: |
+          _build/html/
+
     # Push the book's HTML to github-pages
     - name: Push to GitHub Pages 
       # Only push if on main branch
       if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v3.5.9
+      uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html


### PR DESCRIPTION
Addressing issue #107:
1. CircleCI is still doing a build and archiving the artifact for easy, in-browser viewing. Updated the python docker image
2. Github Actions build also saves the artifact (redundant with CircleCI) but you have to . Also updated the version of the action that pushes the changes to the gh-pages branch once merged with Main.
3. The GitHub Action that adds the CircleCI artifact link to Github for easy access isn't working. This may be because it needs to be merged into main first? See the note in the Readme of that action: https://github.com/larsoner/circleci-artifacts-redirector-action. I fixed the target for the CircleCI job and added the link checker that makes sure that the artifact link is working, and currently the action isn't returning any artifacts at all. If we feel comfortable, my suggestion would be to merge into main. If it still isn't working, I'll take another crack at it.
4. Haven't added docs for the CI build process yet. Waiting to see if we can get the artifact redirector working first. 
