### PR TITLE
Document website build

### DIFF
--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -15,7 +15,3 @@ jobs:
           artifact-path: 0/html/index.html
           circleci-jobs: build_book
           job-title: Click to preview rendered book
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,10 +1,7 @@
 name: deploy-book
 
-# Run on pushes
-on:
-  push:
-    branches:
-      - '*'
+# Run on pushes and pull requests
+on: [push, pull_request]
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Whenever changes are pushed to any branch on GitHub, the book is built (separate
 
 ### Why both GitHub Actions and CircleCI?
 
-- GitHub Actions is the main build tool. In addition to building whenever changes are pushed to any branch, it handles publishing the book when changes are made to the main branch. When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/)b.
+- GitHub Actions is the main build tool. In addition to building whenever changes are pushed to any branch, it handles publishing the book when changes are made to the main branch. When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/).
 - CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the book](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-book) below for details. 
 
 ### How do you preview the website?

--- a/README.md
+++ b/README.md
@@ -10,20 +10,19 @@ https://pyopensci.org/contributing-guide/
 
 pyOpenSci's guide for developing, reviewing, and maintaining packages.
 
-## Automated build and publishing
 
-Whenever a pull request is opened or changes are pushed to any branch of the base repository, the book is built (separately) by both GitHub Actions and CircleCI. 
+## Contributing to this guide
 
-### Why both GitHub Actions and CircleCI?
+We welcome issues and pull requests to improve the content of this guide.
+If you'd like to see an improvement, please [open an issue](https://github.com/pyOpenSci/contributing-guide/issues/new/choose).
 
-- GitHub Actions is the main build tool. In addition to building whenever a pull request is opened from a fork, it handles publishing the book when changes are made to the main branch (e.g. once the pull request is merged). When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/).
-- CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the book](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-book) below for details. 
-
-### How do you preview the website?
-*Note*: If you are working on a fork, you'll have to open a pull request to the base repository to preview the website. 
-- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
-- Via CircleCI: Go to the CircleCI job and select the "Artifacts" tab. Click on "index.html" to preview the built book.
-- Via GitHub Actions alone: GitHub Actions also saves the built html files for preview, but you have to download and unzip the files to your local computer. Go to your deploy-book build in the [Actions tab](https://github.com/pyOpenSci/contributing-guide/actions). Then select "book-html" in the "Artifacts" pane near the bottom of the page. After downloading, unzip the book-html.zip file into a separate directory and open "index.html" from the directory with the unzipped files. The book should open in your web browser.
+To submit a Pull Request with changes:
+1. Create a fork of this repo to make changes.
+2. After making changes, build the book locally from your fork to preview the changes to make sure they appear as expected (see [How to build the guide locally](https://github.com/pyopensci/contributing-guide/#how-to-build-the-guide-locally) below)
+3. When satisfied, push the changes back to GitHub and open a pull request from your fork to the main branch of this repo. 
+4. The Continuous Integration processes will build the book and let you and the PR reviewer(s) preview it in your browser (see [Automated build and publishing](https://github.com/pyopensci/contributing-guide/#automated-build-and-publishing) below).
+5. The reviewer of the PR may request modifications. 
+6. Once satisfied, the reviewer will merge your pull request! Thanks for your contribution!
 
 ## How to build the guide locally
 
@@ -31,7 +30,7 @@ The pyOpenSci guidebook is written using [Jupyter Books](https://github.com/exec
 
 To build the guide locally, take the following steps:
 
-* Clone this repository:
+* Clone this repository (or clone your fork by replacing "pyOpenSci" with your GitHub username):
 
   ```
   git clone https://github.com/pyOpenSci/contributing-guide
@@ -50,14 +49,27 @@ To build the guide locally, take the following steps:
   # Build the book locally!
   $ jupyter-book build .
   ```
+* To view your built book:
 
-  To clean out old pages of your book:
+  Navigate to _build/html/ on your local clone of the repo and open "index.html".
+
+* To clean out old pages of your book (e.g. if you remove a page):
 
   ```
   $ jupyter-book clean .
   ```
 
-## Contributing to this guide
+## Automated build and publishing
 
-We welcome and issues and pull-requests to improve the content of this guide.
-If you'd like to see an improvement, please [open an issue](https://github.com/pyOpenSci/contributing-guide/issues/new/choose).
+Whenever a pull request is opened or changes are pushed to any branch of the base repository, the book is built (separately) by both GitHub Actions and CircleCI. 
+
+### Why both GitHub Actions and CircleCI?
+
+- GitHub Actions is the main build tool. In addition to building whenever a pull request is opened from a fork, it handles publishing the book when changes are made to the main branch (e.g. once the pull request is merged). When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/).
+- CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the the guide from a Pull Request](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-guide-from-a-pull-request) below for details. 
+
+### How do you preview the guide from a Pull Request?
+- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
+- Via CircleCI: Go to the CircleCI job and select the "Artifacts" tab. Click on "index.html" to preview the built book.
+- Via GitHub Actions alone: GitHub Actions also saves the built html files for preview, but you have to download and unzip the files to your local computer. Go to your deploy-book build in the [Actions tab](https://github.com/pyOpenSci/contributing-guide/actions). Then select "book-html" in the "Artifacts" pane near the bottom of the page. After downloading, unzip the book-html.zip file into a separate directory and open "index.html" from the directory with the unzipped files. The book should open in your web browser.
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To submit a Pull Request with changes:
 
 ## How to build the guide locally
 
-The pyOpenSci guidebook is written using [Jupyter Books](https://github.com/executablebooks/jupyter-book).
+The pyOpenSci guidebook is written using [Jupyter Book](https://github.com/executablebooks/jupyter-book).
 
 To build the guide locally, take the following steps:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7101778.svg)](https://doi.org/10.5281/zenodo.7101778)
 
-[![CircleCI](https://circleci.com/gh/pyOpenSci/contributing-guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide)
-
+![deploy-book](https://github.com/pyOpenSci/contributing-guide/actions/workflows/book.yml/badge.svg)  ![Deploy Book](https://github.com/pyOpenSci/contributing-guide/actions/workflows/book.yml/badge.svg)[![CircleCI Book Preview](https://circleci.com/gh/pyOpenSci/contributing-guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide) 
 
 https://pyopensci.org/contributing-guide/
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Whenever a pull request is opened or changes are pushed to any branch of the bas
 - CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the the guide from a Pull Request](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-guide-from-a-pull-request) below for details. 
 
 ### How do you preview the guide from a Pull Request?
-- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
+- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action). See the gif below for a demonstration.
 - Via CircleCI: Go to the CircleCI job and select the "Artifacts" tab. Click on "index.html" to preview the built book.
 - Via GitHub Actions alone: GitHub Actions also saves the built html files for preview, but you have to download and unzip the files to your local computer. Go to your deploy-book build in the [Actions tab](https://github.com/pyOpenSci/contributing-guide/actions). Then select "book-html" in the "Artifacts" pane near the bottom of the page. After downloading, unzip the book-html.zip file into a separate directory and open "index.html" from the directory with the unzipped files. The book should open in your web browser.
+
+![preview_book2](https://user-images.githubusercontent.com/24379590/196472186-ef2c8602-893f-4465-b551-cbecd53cafd9.gif)
+
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,21 @@ https://pyopensci.org/contributing-guide/
 
 pyOpenSci's guide for developing, reviewing, and maintaining packages.
 
-## Build the guide locally
+## Automated build and publishing
+
+Whenever changes are pushed to any branch on GitHub, the book is built (separately) by both GitHub Actions and CircleCI. 
+
+### Why both GitHub Actions and CircleCI?
+
+- GitHub Actions is the main build tool. In addition to building whenever changes are pushed to any branch, it handles publishing the book when changes are made to the main branch. When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/)b.
+- CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the book](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-book) below for details. 
+
+### How do you preview the website?
+- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request or from a branch, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
+- Via CircleCI: Go to the CircleCI job and select the "Artifacts" tab. Click on "index.html" to preview the built book.
+- Via GitHub Actions alone: GitHub Actions also saves the built html files for preview, but you have to download and unzip the files to your local computer. Go to your deploy-book build in the [Actions tab](https://github.com/pyOpenSci/contributing-guide/actions). Then select "book-html" in the "Artifacts" pane near the bottom of the page. After downloading, unzip the book-html.zip file into a separate directory and open "index.html" from the directory with the unzipped files. The book should open in your web browser.
+
+## How to build the guide locally
 
 The pyOpenSci guidebook is written using [Jupyter Books](https://github.com/executablebooks/jupyter-book).
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ pyOpenSci's guide for developing, reviewing, and maintaining packages.
 
 ## Automated build and publishing
 
-Whenever changes are pushed to any branch on GitHub, the book is built (separately) by both GitHub Actions and CircleCI. 
+Whenever a pull request is opened or changes are pushed to any branch of the base repository, the book is built (separately) by both GitHub Actions and CircleCI. 
 
 ### Why both GitHub Actions and CircleCI?
 
-- GitHub Actions is the main build tool. In addition to building whenever changes are pushed to any branch, it handles publishing the book when changes are made to the main branch. When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/).
+- GitHub Actions is the main build tool. In addition to building whenever a pull request is opened from a fork, it handles publishing the book when changes are made to the main branch (e.g. once the pull request is merged). When that happens, it pushes the built html files to the gh-pages branch, which publishes the book to the [website](https://pyopensci.org/contributing-guide/).
 - CircleCI's build is redundant, but it offers an easier way of viewing the built html in browser WITHOUT merging the changes to main or downloading files. See [How do you preview the book](https://github.com/pyopensci/contributing-guide/#how-do-you-preview-the-book) below for details. 
 
 ### How do you preview the website?
-- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request or from a branch, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
+*Note*: If you are working on a fork, you'll have to open a pull request to the base repository to preview the website. 
+- *(Recommended)* Via the artifact redirector workflow: When viewing the checks in a pull request, click "Details" next to the "Click to preview rendered book" to be automatically taken to the CircleCI index.html preview. This is performed using the [circleci-artifacts-redirector-action workflow](https://github.com/larsoner/circleci-artifacts-redirector-action).
 - Via CircleCI: Go to the CircleCI job and select the "Artifacts" tab. Click on "index.html" to preview the built book.
 - Via GitHub Actions alone: GitHub Actions also saves the built html files for preview, but you have to download and unzip the files to your local computer. Go to your deploy-book build in the [Actions tab](https://github.com/pyOpenSci/contributing-guide/actions). Then select "book-html" in the "Artifacts" pane near the bottom of the page. After downloading, unzip the book-html.zip file into a separate directory and open "index.html" from the directory with the unzipped files. The book should open in your web browser.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7101778.svg)](https://doi.org/10.5281/zenodo.7101778)
 
-![deploy-book](https://github.com/pyOpenSci/contributing-guide/actions/workflows/book.yml/badge.svg)  ![Deploy Book](https://github.com/pyOpenSci/contributing-guide/actions/workflows/book.yml/badge.svg)[![CircleCI Book Preview](https://circleci.com/gh/pyOpenSci/contributing-guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide) 
+![deploy-book](https://github.com/pyOpenSci/contributing-guide/actions/workflows/book.yml/badge.svg)  [![CircleCI Book Preview](https://circleci.com/gh/pyOpenSci/contributing-guide.svg?style=svg)](https://circleci.com/gh/pyOpenSci/contributing-guide) 
 
 https://pyopensci.org/contributing-guide/
 


### PR DESCRIPTION
- Added GitHub Actions badge
- Documented build redundancy
- Added explanation of how to view  preview via CircleCI, GitHub Actions, and the artifact redirector workflow. 

@lwasser let me know what you think! Should we add images to the README to help explain how to view the preview? Or more or less detail? 