### PR TITLE
Quick fix: Filter artifact redirect workflow

### DIFF
--- a/.github/workflows/artifact_redirect.yml
+++ b/.github/workflows/artifact_redirect.yml
@@ -5,6 +5,7 @@ on: [status]
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
+    if: "${{ github.event.context == 'ci/circleci: build_book' }}"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step


### PR DESCRIPTION
Only run the artifact redirector when the status that triggers it is a circleCI build